### PR TITLE
Tandem method changes with virtual and override

### DIFF
--- a/base-BDA/trunk/src/PlugIn.cs
+++ b/base-BDA/trunk/src/PlugIn.cs
@@ -131,7 +131,7 @@ namespace Landis.Extension.BaseBDA
 
         }
 
-        public new void InitializePhase2()
+        public override void InitializePhase2()
         {
                 SiteVars.InitializeTimeOfLastDisturbances();
                 reinitialized = true;


### PR DESCRIPTION
Allow Extension-Base-BDA, Extension-LinearWind, Extension-Land-Use-Change to override default implementation of InitalizePhase2() in Core-Model